### PR TITLE
test: fix data collection fragment test

### DIFF
--- a/ground/src/main/java/com/google/android/ground/ui/datacollection/DataCollectionFragment.kt
+++ b/ground/src/main/java/com/google/android/ground/ui/datacollection/DataCollectionFragment.kt
@@ -40,6 +40,7 @@ class DataCollectionFragment : AbstractFragment(), BackPressListener {
   @Inject lateinit var viewPagerAdapterFactory: DataCollectionViewPagerAdapterFactory
 
   private val args: DataCollectionFragmentArgs by navArgs()
+  private lateinit var binding: DataCollectionFragBinding
   private val viewModel: DataCollectionViewModel by hiltNavGraphViewModels(R.id.data_collection)
 
   private lateinit var viewPager: ViewPager2
@@ -50,7 +51,13 @@ class DataCollectionFragment : AbstractFragment(), BackPressListener {
     savedInstanceState: Bundle?
   ): View {
     super.onCreateView(inflater, container, savedInstanceState)
-    val binding = DataCollectionFragBinding.inflate(inflater, container, false)
+    binding = DataCollectionFragBinding.inflate(inflater, container, false)
+    getAbstractActivity().setActionBar(binding.dataCollectionToolbar, showTitle = false)
+    return binding.root
+  }
+
+  override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+    super.onViewCreated(view, savedInstanceState)
     viewPager = binding.root.findViewById(R.id.pager)
     viewPager.isUserInputEnabled = false
     viewPager.offscreenPageLimit = 1
@@ -71,10 +78,6 @@ class DataCollectionFragment : AbstractFragment(), BackPressListener {
 
     binding.viewModel = viewModel
     binding.lifecycleOwner = this
-
-    getAbstractActivity().setActionBar(binding.dataCollectionToolbar, showTitle = false)
-
-    return binding.root
   }
 
   override fun onBack(): Boolean =

--- a/ground/src/test/java/com/google/android/ground/ui/datacollection/DataCollectionFragmentTest.kt
+++ b/ground/src/test/java/com/google/android/ground/ui/datacollection/DataCollectionFragmentTest.kt
@@ -17,7 +17,9 @@
 package com.google.android.ground.ui.datacollection
 
 import android.widget.RadioButton
+import androidx.lifecycle.ViewModelStore
 import androidx.navigation.Navigation
+import androidx.navigation.set
 import androidx.navigation.testing.TestNavHostController
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.espresso.Espresso.onView
@@ -25,10 +27,7 @@ import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.action.ViewActions.typeText
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.*
-import com.google.android.ground.BaseHiltTest
-import com.google.android.ground.R
-import com.google.android.ground.capture
-import com.google.android.ground.launchFragmentInHiltContainer
+import com.google.android.ground.*
 import com.google.android.ground.model.submission.MultipleChoiceTaskData
 import com.google.android.ground.model.submission.TaskDataDelta
 import com.google.android.ground.model.submission.TextTaskData
@@ -325,12 +324,24 @@ class DataCollectionFragmentTest : BaseHiltTest() {
       DataCollectionFragmentArgs.Builder(SURVEY.id, LOCATION_OF_INTEREST.id).build().toBundle()
 
     val navController = TestNavHostController(ApplicationProvider.getApplicationContext())
-    launchFragmentInHiltContainer<DataCollectionFragment>(argsBundle) {
-      fragment = this as DataCollectionFragment
+    navController.setViewModelStore(ViewModelStore()) // required for graph scoped view models.
+    navController.setGraph(R.navigation.nav_graph)
+    navController.setCurrentDestination(R.id.data_collection_fragment, argsBundle)
 
-      navController.setGraph(R.id.data_collection)
-
-      Navigation.setViewNavController(fragment.requireView(), navController)
-    }
+    hiltActivityScenario()
+      .launchFragment<DataCollectionFragment>(
+        argsBundle,
+        preTransactionAction = {
+          fragment = this as DataCollectionFragment
+          this.also {
+            it.viewLifecycleOwnerLiveData.observeForever { viewLifecycleOwner ->
+              if (viewLifecycleOwner != null) {
+                // Bind the controller after the view is created but before onViewCreated is called.
+                Navigation.setViewNavController(fragment.requireView(), navController)
+              }
+            }
+          }
+        }
+      )
   }
 }


### PR DESCRIPTION
Updates the DataCollectionFragment and corresponding test to allow us to set a navigation controller and use HiltNavGraph scoped view models in the test. This requires refactoring the fragment's lifecycle overrides slightly, and also requires reworking our hilt test activity helpers to run actions on fragments either before or after transactions complete.

@JSunde 
